### PR TITLE
chore: add standards enforcement to pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_install: npm i -g npm@6.13.4
 script:
    - commitlint-travis
    - npm run test
+   - grunt standards


### PR DESCRIPTION
If we can go ahead and merge this in, linting will get run for TS and JS files when thew release tool PR lands in master.