### PR TITLE
chore: disable line length for headings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,7 +20,8 @@
    "commands-show-output": true,
    "line-length": {
       "line_length": 90,
-      "code_block_line_length": 130
+      "code_block_line_length": 130,
+      "headings": false
    },
    "no-missing-space-atx": true,
    "no-multiple-space-atx": true,


### PR DESCRIPTION
When I began adding standarization to some of our projects with changelogs, I noticed our line length rules were complaining about changelog headers, which contain alot of content (IE: long compare URLs). I talked to @yokuze and we came to the following conclusion:

We should disable the line length check for headings because:

1. Any increased line length for headings would be an arbitrary value that we would probably violate again in the future anyway
2. We can’t wrap headings to multiple lines like we could with other pieces of content, so they will always be long if they include a link