### PR TITLE
Update markdownlint code block line length to 140

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,7 +20,7 @@
    "commands-show-output": true,
    "line-length": {
       "line_length": 90,
-      "code_block_line_length": 130
+      "code_block_line_length": 140
    },
    "no-missing-space-atx": true,
    "no-multiple-space-atx": true,


### PR DESCRIPTION
This update is to match the standards in eslint-config-silvermine at https://github.com/silvermine/eslint-config-silvermine/blob/master/index.js#L164-L171