### PR TITLE
chore: add markdownlint-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1250,6 +1250,11 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
+    "commander": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
+    },
     "compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -1391,6 +1396,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3173,6 +3183,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3376,6 +3391,16 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.differencewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
+      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -3501,6 +3526,98 @@
       "requires": {
         "markdown-it": "10.0.0"
       }
+    },
+    "markdownlint-cli": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.28.1.tgz",
+      "integrity": "sha512-RBKtRRBzcuAF/H5wMSzb4zvEtbUkyYNEeaDtlQkyH9SoHWPL01emJ2Wrx6NEOa1ZDGwB+seBGvE157Qzc/t/vA==",
+      "requires": {
+        "commander": "~8.0.0",
+        "deep-extend": "~0.6.0",
+        "get-stdin": "~8.0.0",
+        "glob": "~7.1.7",
+        "ignore": "~5.1.8",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "~3.0.0",
+        "lodash.differencewith": "~4.5.0",
+        "lodash.flatten": "~4.4.0",
+        "markdownlint": "~0.23.1",
+        "markdownlint-rule-helpers": "~0.14.0",
+        "minimatch": "~3.0.4",
+        "minimist": "~1.2.5",
+        "run-con": "~1.2.10"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "linkify-it": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+          "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
+          "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        },
+        "markdownlint": {
+          "version": "0.23.1",
+          "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
+          "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+          "requires": {
+            "markdown-it": "12.0.4"
+          }
+        }
+      }
+    },
+    "markdownlint-rule-helpers": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
+      "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -4392,6 +4509,29 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
+    },
+    "run-con": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.10.tgz",
+      "integrity": "sha512-n7PZpYmMM26ZO21dd8y3Yw1TRtGABjRtgPSgFS/nhzfvbJMXFtJhJVyEgayMiP+w/23craJjsnfDvx4W4ue/HQ==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~2.0.0",
+        "minimist": "^1.2.5",
+        "strip-json-comments": "~3.1.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+        }
+      }
     },
     "run-parallel": {
       "version": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-markdownlint": "2.9.0",
     "grunt-stylelint": "0.16.0",
     "markdownlint": "0.19.0",
+    "markdownlint-cli": "0.28.1",
     "stylelint": "13.13.1",
     "stylelint-config-standard": "22.0.0",
     "stylelint-scss": "3.19.0"


### PR DESCRIPTION
Adding the markdownlint CLI tool to dependencies so libraries can have access
to it as an alternative to grunt-markdownlint.