### PR TITLE
feat: Add release scripts for streamlined release process (#27)

### DIFF
--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+   header: '# Changelog\n\nAll notable changes to this project will be documented in this file.\nSee [our coding standards][commit-messages] for commit guidelines.\n\n',
+   changelogFooter: '[commit-messages]: https://github.com/silvermine/silvermine-info/blob/master/commit-history.md#commit-messages',
+   releaseCommitMessageFormat: 'chore: Version bump: v{{currentTag}}',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -665,6 +665,11 @@
         }
       }
     },
+    "@hutson/parse-repository-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+      "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -764,6 +769,11 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
+    },
+    "add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
     },
     "ajv": {
       "version": "6.12.3",
@@ -1024,6 +1034,11 @@
         "node-releases": "^1.1.71"
       }
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1275,6 +1290,35 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "conventional-changelog": {
+      "version": "3.1.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
+      "integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
+      "requires": {
+        "conventional-changelog-angular": "^5.0.12",
+        "conventional-changelog-atom": "^2.0.8",
+        "conventional-changelog-codemirror": "^2.0.8",
+        "conventional-changelog-conventionalcommits": "^4.5.0",
+        "conventional-changelog-core": "^4.2.1",
+        "conventional-changelog-ember": "^2.0.9",
+        "conventional-changelog-eslint": "^3.0.9",
+        "conventional-changelog-express": "^2.0.6",
+        "conventional-changelog-jquery": "^3.0.11",
+        "conventional-changelog-jshint": "^2.0.9",
+        "conventional-changelog-preset-loader": "^2.3.4"
+      }
+    },
     "conventional-changelog-angular": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
@@ -1282,6 +1326,229 @@
       "requires": {
         "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-atom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-codemirror": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-config-spec": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
+      "integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ=="
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+      "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+      "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+      "requires": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-parser": "^3.2.0",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^4.0.0",
+        "git-raw-commits": "^2.0.8",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^4.1.1",
+        "lodash": "^4.17.15",
+        "normalize-package-data": "^3.0.0",
+        "q": "^1.5.1",
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "conventional-changelog-ember": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-eslint": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-express": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-jquery": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-jshint": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
+      "requires": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-preset-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+      "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g=="
+    },
+    "conventional-changelog-writer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
+      "integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
+      "requires": {
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "requires": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -1298,6 +1565,21 @@
         "trim-off-newlines": "^1.0.0"
       }
     },
+    "conventional-recommended-bump": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+      "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
+      "requires": {
+        "concat-stream": "^2.0.0",
+        "conventional-changelog-preset-loader": "^2.3.4",
+        "conventional-commits-filter": "^2.0.7",
+        "conventional-commits-parser": "^3.2.0",
+        "git-raw-commits": "^2.0.8",
+        "git-semver-tags": "^4.1.1",
+        "meow": "^8.0.0",
+        "q": "^1.5.1"
+      }
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -1311,6 +1593,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -1358,8 +1645,7 @@
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1455,6 +1741,16 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1516,6 +1812,47 @@
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dotgitignore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
+      "integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
+      "requires": {
+        "find-up": "^3.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
       }
     },
     "electron-to-chromium": {
@@ -2022,7 +2359,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -2163,6 +2499,14 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "requires": {
+        "null-check": "^1.0.0"
+      }
+    },
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -2207,6 +2551,42 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-pkg-repo": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+      "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
+      "requires": {
+        "@hutson/parse-repository-url": "^3.0.0",
+        "hosted-git-info": "^4.0.0",
+        "through2": "^2.0.0",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
     "get-stdin": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
@@ -2239,6 +2619,32 @@
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "requires": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      }
+    },
+    "git-semver-tags": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+      "requires": {
+        "meow": "^8.0.0",
+        "semver": "^6.0.0"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "requires": {
+        "ini": "^1.3.2"
       }
     },
     "glob": {
@@ -2622,6 +3028,25 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -3124,8 +3549,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3158,6 +3582,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3174,6 +3603,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -3373,6 +3807,33 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3400,6 +3861,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -3795,6 +4261,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3831,6 +4302,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3906,6 +4382,11 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         }
       }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0="
     },
     "num2fraction": {
       "version": "1.2.2",
@@ -4163,6 +4644,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -4269,6 +4755,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -4803,6 +5294,14 @@
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4836,6 +5335,71 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "standard-version": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.2.tgz",
+      "integrity": "sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "conventional-changelog": "3.1.24",
+        "conventional-changelog-config-spec": "2.1.0",
+        "conventional-changelog-conventionalcommits": "4.6.1",
+        "conventional-recommended-bump": "6.1.0",
+        "detect-indent": "^6.0.0",
+        "detect-newline": "^3.1.0",
+        "dotgitignore": "^2.1.0",
+        "figures": "^3.1.0",
+        "find-up": "^5.0.0",
+        "fs-access": "^1.0.1",
+        "git-semver-tags": "^4.0.0",
+        "semver": "^7.1.1",
+        "stringify-package": "^1.0.1",
+        "yargs": "^16.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -4886,6 +5450,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "stringify-package": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg=="
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -4902,6 +5471,11 @@
           "dev": true
         }
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -5424,6 +5998,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5436,6 +6015,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    },
+    "uglify-js": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
+      "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==",
+      "optional": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -5641,6 +6226,11 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -5706,6 +6296,11 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-stylelint": "0.16.0",
     "markdownlint": "0.19.0",
     "markdownlint-cli": "0.28.1",
+    "standard-version": "9.3.2",
     "stylelint": "13.13.1",
     "stylelint-config-standard": "22.0.0",
     "stylelint-scss": "3.19.0"

--- a/release-scripts/finalize-release.sh
+++ b/release-scripts/finalize-release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This script is meant to be used AFTER you have run `prep-changelog.sh` and the CHANGELOG
+# updates for the new version have been reviewed and merged. This script:
+#
+#   1. Bumps the version in package.json and package-lock.json
+#   2. Commits the changes from step 1
+#   3. Creates a git tag called "v${NEW_VERSION}"
+
+# Changelog generation is handled in prep-changelog.sh and generate-changelog-entries.sh
+# so we skip it here.
+./node_modules/.bin/standard-version --skip.changelog "$@"

--- a/release-scripts/generate-changelog-entries.sh
+++ b/release-scripts/generate-changelog-entries.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+./node_modules/.bin/standard-version --skip.commit --skip.tag "$@"
+
+# standard-version does not have a command for generating changelog entries without
+# modifying package.json and package-lock.json. We don't want to perform a version bump in
+# this script; we only want to print the recommended verison number. Therefore, we reset
+# package*.json back to its original state here.
+git checkout package.json
+git checkout package-lock.json

--- a/release-scripts/prep-changelog.sh
+++ b/release-scripts/prep-changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script:
+#
+#   1. Calculates what the next version should be using your repo's commit history and the
+#      Conventional Commits spec: https://www.conventionalcommits.org/en/v1.0.0/
+#   2. Creates and checks out a git branch for CHANGELOG changes called
+#      "changelog-v${NEW_VERSION}"
+#   3. Generates CHANGELOG entries and adds them to CHANGELOG.md
+#   4. Commits the changes on the "changelog-v${NEW_VERSION}" branch
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# 1. Calcuate the next semantic version
+NEW_VERSION=$($SCRIPT_DIR/recommended-bump.sh "$@");
+
+if [ -z "$NEW_VERSION" ]
+then
+   >&2 echo $'Error creating new version.\n'
+   exit 1;
+fi
+
+# 2. Checkout a new branch for the changelog updates
+echo "Creating a new branch for the CHANGELOG updates: changelog-v$NEW_VERSION"
+git checkout -b "changelog-v$NEW_VERSION" || exit 1
+
+# 3. Generate the CHANGELOG entries
+echo "Generating CHANGELOG entries for v$NEW_VERSION"
+$SCRIPT_DIR/generate-changelog-entries.sh "$@" || exit 1
+
+# 4. Commit the changes
+echo "Committing CHANGELOG.md"
+git add CHANGELOG.md
+git commit -m "chore: Update CHANGELOG for v$NEW_VERSION"

--- a/release-scripts/recommended-bump.sh
+++ b/release-scripts/recommended-bump.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+HAS_PKG_CHANGES=$(git status -s | grep package.*.json)
+
+if [ ! -z "$HAS_PKG_CHANGES" ]
+then
+   >&2 echo $'\n------------------------------ ERROR ------------------------------'
+   >&2 echo $'You have uncommitted changes in package.json or package-lock.json. '
+   >&2 echo $'This script will overwrite uncommitted changes to package.json '
+   >&2 echo $'and package-lock.json. Commit or stash the changes first, then '
+   >&2 echo $'re-run this script.'
+   >&2 echo $'-------------------------------------------------------------------\n\n'
+   exit 1;
+fi
+
+./node_modules/.bin/standard-version --skip.commit --skip.tag --skip.changelog "$@" > /dev/null
+
+NODE_VERSION=$(node -p -e "require('./package.json').version")
+
+# standard-version does not have a command for calculating the recommended version bump
+# without modifying package.json and package-lock.json. We don't want to perform a version
+# bump in this script; we only want to print the recommended verison number. Therefore, we
+# reset package*.json back to its original state here.
+git checkout package.json &> /dev/null
+git checkout package-lock.json &> /dev/null
+
+echo $NODE_VERSION


### PR DESCRIPTION
This PR provides a set of scripts and configuration to simplify the version bumping and
CHANGELOG generation process. The process works for both open-source projects hosted on
Github, or closed-source projects hosted on a private hosting instance such as Gitlab.

This lengthy comment is broken into two major sections: 1) An overview of the current process
and an outline of the problems that it has, some of which are solved by this PR. This is
to remind the reviewer of the current process so they can compare it to the new process.
2) Integration and usage instructions for the new scripts.

## Current Process

#### Initial Release Candidate

Here is an outline of the current version-bumping process, starting with the process for
creating the first release candidate for a new version. This process assumes that the
project has a dependency on `standard-version` and an NPM script called "release" defined
as: `"release": "standard-version"`.

1. In the project's root folder, check out a new branch called
   `prep-v${WHAT_YOU_THINK_THE_NEW_VERSION_WILL_BE}`
1. Run `npm run release -- --skip.commit --skip.tag --prerelease=rc`
   * This command calculates the next recommended version and CHANGELOG entries from the
     git log's commit messages and outputs them to CHANGELOG.md.
   * It also bumps the version in `package.json` and `package-lock.json`. We don't want to
     do that just yet, but there's no way to tell standard-version to skip that step
     without breaking CHANGELOG generation. (I can provide more details on _why_ this is
     so, as needed. If you're curious, ping me directly.)
   * Note that this command adds the CHANGELOG entries under a release candidate heading,
     e.g. `### 1.3.0-rc.0`. We do not include release candidate headings in the final
     version, but we do need them for release candidate versions for two reasons: 1) They
     are convenient to refer to while the project is in its release candidate phase. 2)
     standard-version does not provide a way to generate a list of CHANGELOG entries using
     a specific range of commits or tags. It will only ever generate the list from the
     _previous tagged version_ to `HEAD`, so when it comes time to create the CHANGELOG
     for the final version, we need to already have the entries from the previous release
     candidates.
1. Get rid of the unwanted changes to `package.json` and `package-lock.json`. (I use `git
   checkout package*`)
1. Open CHANGELOG.md and review the new CHANGELOG entries to make sure they look correct.
1. Commit the new entries with the message: `chore: Update CHANGELOG for v${NEW_VERSION}`
1. Run `npm run release -- --skip.changelog --prerelease=rc`.
   * This command bumps the version in `package.json` and `package-lock.json`, commits
     them, and creates a new `v${NEW_VERSION}` tag.
1. Push the branch to a remote and open a PR/MR.
1. Once the PR/MR is reviewed and merged, push the new `v${NEW_VERSION}` tag.

#### Subsequent Release Candidates

After the initial release candidate, we may need to create more release candidates before
the final version. If the changes in the new release candidate are only fixes for features
that are in the current version, we may skip CHANGELOG generation for the sake of
simplicity, since we do not want to include CHANGELOG entries for fixes for features
introduced in the current version and follow an abbreviated process:

1. Check out a new branch, e.g. `git checkout -b prep-v1.3.0-rc.1` if the the previous
   release candidate was  `v1.3.0-rc.0`.
1. `npm run release -- --skip.changelog --prerelease=rc`
1. Push the branch and open a PR/MR.
1. Once the PR/MR is reviewed and merged, push the new `v${NEW_VERSION}` tag.

In practice, however, we sometimes add new bug fixes that should be added to the CHANGELOG
(not just bug fixes for features in the current version). When that happens, we must
follow the longer process in the "Initial Release Candidate" section again.

#### Final Version

Follow the process in the "Initial Release Candidate" section, but with these differences:

1. Omit the `--prerelease` flag from all commands
1. After generating the final CHANGELOG heading, delete the previous release candidate
   headings and merge/re-organize the entries under their appropriate "Feature", "Bug
   Fix", etc. headings. This process is described in more detail in the "Creating the
   Final Version" subheading near the end of this comment.

### Problems With the Current Process

1. When you check out the `prep-v${NEW_VERSION}` branch, you have to already know what the
   next version will be if you want to include the version in the branch name. To get the
   next version, you either have to look at the `git log` and figure it out or do a
   dry-run of an `npm release` command to see what the next version is before creating
   your branch. Or create a temporary branch name and rename the branch after the version
   bumping process is finished.
1. The command that generates the CHANGELOG also modifies package.json and
   package-lock.json before we need it and you have to manually back those changes out
   before continuing.
1. There are a number of CLI flags that you have to pass to each step and it's easy to
   forget to pass one and what they're called. It's certainly not beginner-friendly.
1. If the reviewer catches something you missed in the CHANGELOG changes, you have to
   delete the tag and version bump commit, fixup the CHANGELOG, and then re-run the 
   `npm run release -- --skip.changelog --prerelease=rc` command to regenerate the version
   bump commit and tag.
1. When creating the final version, you have to manually merge the CHANGELOG entries from
   previous release candidate versions into a single final version.
   * The reviewer will notice later that the scripts introduced in this PR _do not solve this
     problem._ Doing so would have required switching from standard-version to some other
     CLI tool, which was out of scope for this PR.


## New Process

### Goals

1. Simplify the release process and commands without writing a new/complex release tool right now.
1. Allow someone to run the release process without having to be familiar with the project itself and
what entries _should_ appear in the CHANGELOG.
   * The MR that's submitted during this new process is for the CHANGELOG changes only. The MR
      should be assigned to the developer who is most familiar with the project and the changes in the
      new version.

Here is a set of instructions for adding these scripts to one of our repos, creating a
release candidate version, and creating a final version.

If this process is approved, these instructions will be the basis for another PR to the
[`silvermine-info` repo](https://github.com/silvermine/silvermine-info) to document the new release process.

## Adding These Release Scripts to a Project

1. `npm i -DE @silvermine/standardization`
2. Ensure that your `package.json` file has [a `repository.url` field](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository) with the
   URL to the canonical repo for this project in your Git hosting solution, e.g.
   `https://github.com/silvermine/event-emitter.git` for the `@silvermine/event-emitter`
   project in Github.
   * This is necessary because standard-version needs to know the URL to your Git hosting
     solution so that it can make links to "compare URLs" in the CHANGELOG (e.g. the ["9.4.0" link here](https://github.com/conventional-changelog/standard-version/blob/master/CHANGELOG.md#940-2021-12-31)).
     standard-version looks at `package.json`'s `repository.url` field first, and then
     falls back to the `origin` git remote's URL. Until recently, we've been relying on the `origin`
     remote URL, but since we've started naming our `origin` remote `canonical` in some
     instances, standard-version can't find a URL to use. standard-version does not allow
     you to configure the name of remote it uses to get the URL. Therefore, I suggest we
     consistently use the `repository.url` field in our projects.
3. Create a symlink to: `./node_modules/@silvermine/standardization/.versionrc.js` in your
   project's root folder.
4. Add these NPM scripts to your `package.json` file:

```json
"release:prep-changelog": "./node_modules/@silvermine/standardization/release-scripts/prep-changelog.sh",
"release:finalize": "./node_modules/@silvermine/standardization/release-scripts/finalize-release.sh"
```
5. (Optional) If you are using an issue tracking system other than what your Git hosting
   solution provides (e.g. Azure DevOps instead of Github Issues), add this config to
   `package.json`:

```json
"standard-version": {
   "issueUrlFormat": "https://${YOUR_ADO_INSTANCE}/tickets/{{id}}"
}
```

### Creating a Release Candidate

   1. Check out the `master` branch (or a `release_*` branch if the release you are
      creating is not based off of `master` ). Fetch and rebase the latest changes from
      the corresponding remote branch. For example, if you are working off of master: `git
      fetch --all; git rebase origin/master`
   2. Run `npm release:prep-changelog -- --prerelease=rc`. You should now have a git
      branch called `changelog-v${NEW_VERSION}` checked out with the CHANGELOG updates
      committed.
   3. If the CHANGELOG output results in a heading with no new CHANGELOG entries, delete
      the branch and continue to step 5. Otherwise, push the branch to the correct remote
      repo, open a PR/MR, and continue with step 4.
   4. After the CHANGELOG PR/MR is reviewed and merged, fetch and rebase again so that you
      have the CHANGELOG updates in your local repo.
   5. Run `npm run release:finalize -- --prerelease=rc`. You should now have a git branch
      called `prep-v${NEW_VERSION}` checked out, with version bumps in
      package.json/package-lock.json committed along with a new tag called
      `v${NEW_VERSION}`.
   6. Push the branch to the correct remote repo and open a PR/MR.
   7. Once the PR/MR is reviewed and merged and the build pipelines finish, push the
      `v${NEW_VERSION}` tag to `origin` or `canonical`.

### Creating the Final Version

   1. Check out the `master` branch (or a `release_*` branch if the release you are
      creating is not based off of `master` ). Fetch and rebase the latest changes from
      the corresponding remote branch. For example, if you are working off of master: `git
      fetch --all; git rebase origin/master`
   2. Run `npm release:prep-changelog`. You should now have a git branch called
      `changelog-v${NEW_VERSION}` checked out with the CHANGELOG updates committed.
   3. We do not want to include individual headings for the previous release candidates in
      the final version's CHANGELOG. So, we need to remove the headings and move any
      CHANGELOG entries under them to the final version's heading. For example, consider a
      CHANGELOG that looks like this:

```md
### [1.0.0](https://${REMOTE_URL}/compare/v1.0.0-rc.1...v1.0.0) (2021-11-22)

### [1.0.0-rc.1](https://${REMOTE_URL}/compare/v1.0.0-rc.0...v1.0.0-rc.1) (2021-11-19)

### Bug Fixes

* A bugfix that we decided to add to this release ([4fff161](https://${REMOTE_URL}/commit/4fff161bee343d3caaaf74d4d576456437cfaa8f))


### [1.0.0-rc.0](https://${REMOTE_URL}/compare/v0.9.0...v1.0.0-rc.0) (2021-11-09)

### Features

* Remove flux capacitor from DeLorean ([3db39af](https://${REMOTE_URL}/commit/3db39af31ea515da9f74c0ad3f163965f41a0f59))

### Bug Fixes

* Ensure flux capacitor can reach 1.21 gigawatts when needed ([9fd45e2](https://${REMOTE_URL}/commit/9fd45e29ded483ae1b065a1bc78f5506401c20b3))
```

The headings in the CHANGELOG for the final version should look like this:

```md
### [1.0.0](https://${REMOTE_URL}/compare/v1.0.0-rc.1...v1.0.0) (2021-11-22)

### Features

* Remove flux capacitor from DeLorean ([3db39af](https://${REMOTE_URL}/commit/3db39af31ea515da9f74c0ad3f163965f41a0f59))

### Bug Fixes

* A bugfix that we decided to add to this release ([4fff161](https://${REMOTE_URL}/commit/4fff161bee343d3caaaf74d4d576456437cfaa8f))
* Ensure flux capacitor can reach 1.21 gigawatts when needed ([9fd45e2](https://${REMOTE_URL}/commit/9fd45e29ded483ae1b065a1bc78f5506401c20b3))
```

   3. Update the diff link in the final version's CHANGELOG heading so that all commits in
      the new version are included. In the example above, the CHANGELOG heading looks like
      this:

```md
### [1.0.0](https://${REMOTE_URL}/compare/v1.0.0-rc.1...v1.0.0) (2021-11-22)
```
   Note that the version range in the URL is `v1.0.0-rc.1...v1.0.0`. We want to include
   _all_ of the changes in `v1.0.0`, not just the ones since the last release candidate.
   If, for example, the last released version was `v0.9.0`, update the URL to:

```md
### [1.0.0](https://${REMOTE_URL}/compare/v0.9.0...v1.0.0) (2021-11-22)
```

   4. Push the branch to the correct remote repo and open a PR/MR.
   5. After the CHANGELOG PR/MR is reviewed and merged, fetch and rebase again so that you
      have the CHANGELOG updates in your local repo.
   6. Run `npm run release:finalize`. You should now have a commit with version bumps in
      package.json/package-lock.json along with a new tag called `v${NEW_VERSION}`.
   7. Push the changes to the branch that you are on (either `master` or a `release_*`
      branch) to the canonical remote (either `origin` or `canonical`).
   8. Push the tag to the canonical remote: `git push ${ORIGIN_OR_CANONICAL}
      v${NEW_VERSION}`

