### PR TITLE
chore: remove direct markdownlint dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install: npm i -g npm@6.14.12
 
 script:
    - commitlint-travis
+   - npm run standards
    - npm run test
-   - grunt standards

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,8 +13,6 @@ module.exports = function(grunt) {
       js: {
          all: [ '*.js', 'scripts/**/*.js' ],
       },
-
-      markdownlintConfig: grunt.file.readJSON('.markdownlint.json'),
    };
 
    grunt.initConfig({
@@ -25,20 +23,10 @@ module.exports = function(grunt) {
       eslint: {
          target: config.js.all,
       },
-
-      markdownlint: {
-         all: {
-            src: [ ...config.docs.src.md ],
-            options: {
-               config: config.markdownlintConfig,
-            },
-         },
-      },
    });
 
    grunt.loadNpmTasks('grunt-eslint');
-   grunt.loadNpmTasks('grunt-markdownlint');
 
    grunt.registerTask('default', [ 'standards' ]);
-   grunt.registerTask('standards', [ 'eslint', 'markdownlint' ]);
+   grunt.registerTask('standards', [ 'eslint' ]);
 };

--- a/README.md
+++ b/README.md
@@ -264,15 +264,22 @@ npm release:finalize -- --prerelease rc
 
 ### Migration to `standards` NPM script
 
-At some point we will be migrating away from grunt as a task runner. To facilitate this future
-transition, we should begin adding a NPM script called `standards` to `package.json`. Where
-impractical to remove grunt altogether from a project, we should:
+We are in the process of migrating away from grunt as a task runner. This being the case,
+we are switching from `grunt standards` to `npm run standards` as our default "run the
+linting/standards checks" command. The goal is to help reduce cognitive load for
+developers when they begin work on a project. For example, they will not have to
+ask the question:
 
-   * Add the `standards` NPM script
-   * Add calls to any linting and standards-related NPM scripts to this new script
-   * Add a call to `grunt standards` inside of this script
-   * Remove calls to `grunt standards` from CI configuration files (`.travis.yml`, etc)
-   * Add a call to `npm run standards` to these CI configuration files
+> "What's the standards command I need to run? Does this project still use grunt?".
+
+When updating projects, even if they still use `grunt` as the primary build tool,
+we should:
+
+1. Add a new `standards` NPM script which will run all the linting and standards-related scripts
+   * If the project still relies on `grunt standards`, this script should contain a call to
+     `grunt standards`
+2. Replace any calls to `grunt standards` with `npm run standards` in CI configuration files
+   (`.travis.yml`, etc)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -91,27 +91,22 @@ for your editor:
      before running `npm test`
 
 
-### markdownlint
+### Markdownlint
 
-Add the following configuration to your Gruntfile.js, register the task, and add
-the `markdownlint` task to the `standards` command:
+Add the following script to package.json, and adjust the ignore argument as needed
+to suit the needs of the project. Then add a call to markdownlint in the `standards`
+NPM script.
 
-```javascript
-// Inside initConfig...
-markdownlint: {
-   all: {
-      src: [ './path/to/markdown/file.md' ],
-      options: {
-         config: grunt.file.readJSON('.markdownlint.json'),
-      },
-   },
-},
+See [Migration to `standards` NPM script](#migration-to-standards-npm-script)
 
-// Register the task:
-grunt.loadNpmTasks('grunt-markdownlint');
+```json
+{
+   "scripts": {
+      "markdownlint": "markdownlint -c .markdownlint.json -i CHANGELOG.md '{,!(node_modules)/**/}*.md'",
+      "standards": "npm run markdownlint && grunt standards"
+   }
+}
 
-// Add the command to `grunt standards`:
-grunt.registerTask('standards', [ 'markdownlint' ]);
 ```
 
 
@@ -265,6 +260,28 @@ rc` option (Values like `alpha` and `beta` also work). For example:
 npm release:preview -- --prerelease rc
 npm release:prep-changelog -- --prerelease rc
 npm release:finalize -- --prerelease rc
+```
+
+### Migration to `standards` NPM script
+
+At some point we will be migrating away from grunt as a task runner. To facilitate this future
+transition, we should begin adding a NPM script called `standards` to `package.json`. Where
+impractical to remove grunt altogether from a project, we should:
+
+   * Add the `standards` NPM script
+   * Add calls to any linting and standards-related NPM scripts to this new script
+   * Add a call to `grunt standards` inside of this script
+   * Remove calls to `grunt standards` from CI configuration files (`.travis.yml`, etc)
+   * Add a call to `npm run standards` to these CI configuration files
+
+Example:
+
+```json
+{
+   "scripts": {
+      "standards": "npm run markdownlint && grunt standards"
+   }
+}
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,25 +876,25 @@
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
     },
@@ -1152,6 +1152,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2623,16 +2624,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       },
       "dependencies": {
         "braces": {
@@ -2651,19 +2651,40 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           }
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
         },
         "to-regex-range": {
           "version": "5.0.1",
@@ -2693,9 +2714,9 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -2993,9 +3014,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3009,6 +3030,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       },
@@ -3017,6 +3039,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -3133,6 +3156,20 @@
         "rimraf": "~3.0.2"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "grunt-cli": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.2.tgz",
@@ -3698,14 +3735,6 @@
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "grunt-markdownlint": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/grunt-markdownlint/-/grunt-markdownlint-2.9.0.tgz",
-      "integrity": "sha512-jLzTzNVZN/u2iblV2j+2xfJGG+Mv8NMl5CAOWNQftV7SOHnstwR/tiZPac8ZTmJFqwAqCwafIvu9wP2naAS8Og==",
-      "requires": {
-        "markdownlint": "^0.19.0"
       }
     },
     "grunt-stylelint": {
@@ -4530,9 +4559,9 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -4587,16 +4616,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.differencewith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -4716,43 +4735,51 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        }
       }
     },
     "markdownlint": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.19.0.tgz",
-      "integrity": "sha512-+MsWOnYVUH4klcKM7iRx5cno9FQMDAb6FC6mWlZkeXPwIaK6Z5Vd9VkXkykPidRqmLHU2wI+MNyfUMnUCBw3pQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "requires": {
-        "markdown-it": "10.0.0"
+        "markdown-it": "12.3.2"
       }
     },
     "markdownlint-cli": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.28.1.tgz",
-      "integrity": "sha512-RBKtRRBzcuAF/H5wMSzb4zvEtbUkyYNEeaDtlQkyH9SoHWPL01emJ2Wrx6NEOa1ZDGwB+seBGvE157Qzc/t/vA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+      "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
       "requires": {
-        "commander": "~8.0.0",
-        "deep-extend": "~0.6.0",
-        "get-stdin": "~8.0.0",
-        "glob": "~7.1.7",
-        "ignore": "~5.1.8",
+        "commander": "~9.0.0",
+        "get-stdin": "~9.0.0",
+        "glob": "~7.2.0",
+        "ignore": "~5.2.0",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "~3.0.0",
-        "lodash.differencewith": "~4.5.0",
-        "lodash.flatten": "~4.4.0",
-        "markdownlint": "~0.23.1",
-        "markdownlint-rule-helpers": "~0.14.0",
-        "minimatch": "~3.0.4",
-        "minimist": "~1.2.5",
+        "markdownlint": "~0.25.1",
+        "markdownlint-rule-helpers": "~0.16.0",
+        "minimatch": "~3.0.5",
         "run-con": "~1.2.10"
       },
       "dependencies": {
@@ -4761,33 +4788,15 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "commander": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
-          "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
-        },
-        "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-        },
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
+        "get-stdin": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+          "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA=="
         },
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -4797,40 +4806,20 @@
             "argparse": "^2.0.1"
           }
         },
-        "linkify-it": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
-          "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+        "minimatch": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+          "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
           "requires": {
-            "uc.micro": "^1.0.1"
-          }
-        },
-        "markdown-it": {
-          "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-          "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "~2.1.0",
-            "linkify-it": "^3.0.1",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          }
-        },
-        "markdownlint": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-          "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
-          "requires": {
-            "markdown-it": "12.0.4"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
     },
     "markdownlint-rule-helpers": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
-      "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -6099,7 +6088,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "release:preview": "node ./scripts/release.js preview",
     "release:prep-changelog": "node ./scripts/release.js prep-changelog",
     "release:finalize": "node ./scripts/release.js finalize",
-    "standards": "npm run commitlint && grunt standards"
+    "markdownlint": "markdownlint -c .markdownlint.json -i CHANGELOG.md '{,!(node_modules)/**/}*.md'",
+    "standards": "npm run markdownlint && grunt standards"
   },
   "repository": {
     "type": "git",
@@ -38,10 +39,8 @@
     "conventional-changelog-conventionalcommits": "4.6.3",
     "conventional-recommended-bump": "6.1.0",
     "git-semver-tags": "4.1.1",
-    "grunt-markdownlint": "2.9.0",
     "grunt-stylelint": "0.16.0",
-    "markdownlint": "0.19.0",
-    "markdownlint-cli": "0.28.1",
+    "markdownlint-cli": "0.31.1",
     "semver": "7.3.5",
     "stylelint": "13.13.1",
     "stylelint-config-standard": "22.0.0",


### PR DESCRIPTION
We formerly included `markdownlint`, `grunt-markdownlint` and `markdownlint-cli` in this library. This resulted
in multiple resolved versions of `markdownlint`, and in some projects, conflicting rulesets due to how different versions handle their implementation. Since we are switching to using `markdownlint-cli`, which comes bundled with it's own markdownlint version as a dependency.

Additionally, we are interested in moving away from grunt, so this implements an NPM script for `standards`, and calrifies it's usage in the readme.
