### PR TITLE
chore: temporarily disable Travis pipeline for latest Node.js 18.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "node" # Latest node version
+  # TODO: Restore the pipeline for latest Node.js when Travis fixes their
+  # pipeline dependency problems. See #39
+  # - "node" # Latest node version
   - "lts/*" # Latest LTS version
   - "14"
   - "12"


### PR DESCRIPTION
This is a temporary pipeline patch to disable runs for Node 18.x, since Travis Linux images are missing a compiler dependency.

See #39 