### PR TITLE
Add acknowledgement message for releases with no changelog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ At a high-level, the process for releasing a new version of a package is:
    1. Run `npm run release:prep-changelog`. You should now be on a branch named
       `changelog-v${NEW_VERSION}` containing the automatically generated changelog
       additions.
-      * If you receive the message "There were no changelog entries generated" and this is
-        expected, please proceed to [Perform the Version Bump](#perform-the-version-bump).
       * If the changelog needs to be edited, please make the needed adjustments and amend
         your edits to the "chore: update changelog" commit.
       * When preparing the changelog for a final version, the release candidate changelog

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -101,9 +101,10 @@ function createChangelogAdditions(opts) {
 
       changelogStream.on('end', () => {
          // In the event the there are no entries added to the changelog (i.e. it's just a
-         // changelog header), we don't want to add anything to the changelog
+         // changelog header), we add a line acknowledging this release only contains
+         // documentation or internal changes.
          if (content.trim().split('\n').length === 1) {
-            resolve(undefined);
+            content += '_This release only contains documentation or internal changes._\n\n';
          }
 
          resolve(content);
@@ -228,11 +229,7 @@ const main = async (argv) => {
          });
 
          if (!changelogAdditions) {
-            console.warn(chalk.yellow(
-               'There were no changelog entries generated. Aborting changelog preparation.'
-               + ' If this is expected (e.g. only documentation or internal changes were made),'
-               + ' this version can be finalized without an update to the changelog.'
-            ));
+            console.warn(chalk.yellow('There were no changelog entries generated. Aborting changelog preparation.'));
             return;
          }
 


### PR DESCRIPTION
By detecting if the changelog content is empty, the release script would return `undefined` which then caused the release to abort.  We just change the logic to instead insert a line that indicates, "This release only contains documentation or internal changes." That prevents the release from aborting and provides a meaningful comment to fill the void of any otherwise empty space where the changelog entries would appear. 

As explained in #49, this enables us to still add releases to the changelog even when all the changes are internal/documentation. 