### PR TITLE
chore: set package.json indent size to 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,7 @@ insert_final_line = true
 indent_style = space
 indent_size = 3
 
+[package.json]
+indent_size = 2
+
 charset = utf-8


### PR DESCRIPTION
NPM enforces its own indent rules and when package.json is updated by NPM during various processes, will always revert the indent size to 2. Adding an override to our standard indent size for package.json makes our IDE lives easier. See <https://github.com/npm/npm/pull/3062> for context.