### PR TITLE
fix: disable MD051/link-fragments

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -29,5 +29,6 @@
    "no-alt-text": false,
    "code-block-style": { "style": "fenced" },
    "code-fence-style": { "style": "backtick" },
-   "no-inline-html": false
+   "no-inline-html": false,
+   "link-fragments": false
 }


### PR DESCRIPTION
While we like the idea of MD051, in practice, the rule often flags links that are actually valid for other target rendering environments. For example, MD051 expects a heading like `this/is - an/awesome(heading)` to have an anchor of `thisis---anawesomeheading`. However, GitLab renders this a `thisis-anawesomeheading` and markdown-it-anchor renders it as `this-is-an-awesome-heading`.