### PR TITLE
fix: update markdownlint config for duplicate headers

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,8 +20,8 @@
       "code_block_line_length": 140,
       "tables": false
    },
-   "no-duplicate-header": {
-      "allow_different_nesting": true
+   "no-duplicate-heading": {
+      "siblings_only": true
    },
    "no-trailing-punctuation":{
       "punctuation":  ".,;:"


### PR DESCRIPTION
- rename no-duplicate-header to no-duplicate-heading https://github.com/DavidAnson/markdownlint/commit/a9a77940c5502e21ed0b2a3ac5976dbcc0d5c52a

- rename allow_different_nesting to siblings_only https://github.com/DavidAnson/markdownlint/commit/f2725178b1e83b07d7f7cc2db64d42f6aa14b8a1