### PR TITLE
feat: Add Rust formatting defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ indent_style = space
 indent_size = 3
 
 charset = utf-8
+
+[*.rs]
+indent_size = 4
+max_line_length = 100


### PR DESCRIPTION
Rustfmt currently has the following [options](https://github.com/rust-lang/style-team/issues/1):
```
    max_width: usize, 100, "Maximum width of each line";
    ideal_width: usize, 80, "Ideal width of each line";
    tab_spaces: usize, 4, "Number of spaces per tab";
    hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";
```

To ensure .editorconfig doesn't fight `rustfmt` we adjust to match the Rust language style guidelines.