### PR TITLE
fix: allow blank lines between CSS declarations

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -49,7 +49,10 @@ rules:
    declaration-colon-space-after: always
    declaration-colon-space-before: never
    declaration-block-trailing-semicolon: always
-   declaration-empty-line-before: never
+   declaration-empty-line-before:
+      - never
+      - ignore:
+         - after-declaration
    comment-whitespace-inside: always
    rule-empty-line-before:
       - always


### PR DESCRIPTION
@kmuncie last week was the first time I'd done any hands-on CSS dev in any of our repos in a long time. This rule kept tripping me up because there would be conceptually-logical groupings of CSS declarations that it made sense to separate (e.g. separate CSS var defaults, from grid/flex layout declarations, from font and color declarations). But this rule would complain when I put any blank lines between declarations. Having this rule seems to conflict with our [principles on blank lines](https://github.com/silvermine/silvermine-info/blob/master/coding-standards.md#blank-lines). This PR is an attempt to make the linting match those principles, but there may be [more things to ignore, or a better way to structure the rule](https://stylelint.io/user-guide/rules/declaration-empty-line-before/#ignore-after-comment-after-declaration-first-nested-inside-single-line-block).

cc @yokuze 